### PR TITLE
Adds empty register() method in Service provider for Laravel 5.2

### DIFF
--- a/src/MailtrapServiceProvider.php
+++ b/src/MailtrapServiceProvider.php
@@ -19,4 +19,14 @@ class MailtrapServiceProvider extends ServiceProvider
         Model::boot($client);
         Model::returnArraysAsLaravelCollections();
     }
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
 }


### PR DESCRIPTION
Defines an emptoy `register()` method in MailtrapServiceProvider.php to match definition in `/laravel/framework/src/Illuminate/Support/ServiceProvider.php` in Laravel 5.2